### PR TITLE
Mark plugin as not compatible with WordPress

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -15,6 +15,7 @@
     "forum": "https://forum.matomo.org",
     "source": "https://github.com/matomo-org/plugin-Provider"
   },
+  "wordpress-compatible": false,
   "authors": [
     {
       "name": "Matomo",


### PR DESCRIPTION
fix https://github.com/matomo-org/plugin-Provider/issues/10

created https://github.com/matomo-org/wp-matomo/issues/446 as a follow up to make this plugin compatible.