### PR TITLE
Remove code for event that does no longer exist

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -42,17 +43,6 @@ class Provider extends \Piwik\Plugin
         // add column hostname / hostname ext in the visit table
         $query = "ALTER TABLE `" . Common::prefixTable('log_visit') . "` DROP `location_provider`";
         Db::exec($query);
-    }
-
-    public function postLoad()
-    {
-        Piwik::addAction('Template.footerUserCountry', ['Piwik\Plugins\Provider\Provider', 'footerUserCountry']);
-    }
-
-    public static function footerUserCountry(&$out)
-    {
-        $out .= '<h2 piwik-enriched-headline>' . Piwik::translate('Provider_WidgetProviders') . '</h2>';
-        $out .= FrontController::getInstance()->fetchDispatch('Provider', 'getProvider');
     }
 
     /**


### PR DESCRIPTION
### Description:

The event `Template.footerUserCountry` has been removed a long time ago, so there shouldn't be any need for keeping it.

replaces #27 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
