### PR TITLE
Add campaign tracking parameters for all links within Matomo app that link to matomo.org

### DIFF
--- a/Reports/GetProvider.php
+++ b/Reports/GetProvider.php
@@ -15,6 +15,7 @@ use Piwik\Plugin\Report;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\Provider\Columns\Provider;
 use Piwik\Report\ReportWidgetFactory;
+use Piwik\Url;
 use Piwik\Widget\WidgetsList;
 
 class GetProvider extends Report
@@ -45,7 +46,7 @@ class GetProvider extends Report
         if (!Common::getRequestVar('disableLink', 0, 'int')) {
             $message .= ' ' . Piwik::translate(
                     'General_SeeThisFaq',
-                    ['<a href="https://matomo.org/faq/general/faq_52/" rel="noreferrer noopener" target="_blank">', '</a>']
+                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/general/faq_52/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
                 );
         }
         $view->config->show_footer_message = $message;

--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "license": "GPL v3+",
   "homepage": "https://matomo.org",
   "require": {
-    "matomo": ">=5.0.0-b4,<6.0.0-b1"
+    "matomo": ">=5.0.0-rc6,<6.0.0-b1"
   },
   "support": {
     "email": "hello@matomo.org",

--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "license": "GPL v3+",
   "homepage": "https://matomo.org",
   "require": {
-    "matomo": ">=5.0.0-rc6,<6.0.0-b1"
+    "matomo": ">=5.0.0-rc5,<6.0.0-b1"
   },
   "support": {
     "email": "hello@matomo.org",


### PR DESCRIPTION
### Description:

This PR is a companion change to https://github.com/matomo-org/matomo/pull/21375

It changes links to matomo.org to include campaign parameters to track the location in the application from which the link was followed.

It depends on changes in the parent PR and should only be merged along with it.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
